### PR TITLE
Retarget extension documentation URL

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,7 @@
 	"author": [
 		"Nischay Nahata"
 	],
-	"url": "https://www.mediawiki.org/wiki/Extension:MassPasswordReset",
+	"url": "https://github.com/nischayn22/MassPasswordReset#masspasswordreset",
 	"license-name": "GPL-2.0-or-later",
 	"type": "specialpage",
 	"requires": {


### PR DESCRIPTION
Instead of pointing to a missing page on MediaWiki.org, use the repository's documentation.